### PR TITLE
Detector framework performance improvements

### DIFF
--- a/aida/pom.xml
+++ b/aida/pom.xml
@@ -8,7 +8,7 @@
 
   <parent>
     <groupId>org.lcsim</groupId>
-    <artifactId>lcsim-parent</artifactId>
+    <artifactId>lcsim</artifactId>
     <version>4.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>

--- a/analysis/pom.xml
+++ b/analysis/pom.xml
@@ -9,7 +9,7 @@
 
   <parent>
     <groupId>org.lcsim</groupId>
-    <artifactId>lcsim-parent</artifactId>
+    <artifactId>lcsim</artifactId>
     <relativePath>../pom.xml</relativePath>
     <version>4.0-SNAPSHOT</version>
   </parent>

--- a/cal-calib/pom.xml
+++ b/cal-calib/pom.xml
@@ -9,7 +9,7 @@
 
   <parent>
     <groupId>org.lcsim</groupId>
-    <artifactId>lcsim-parent</artifactId>
+    <artifactId>lcsim</artifactId>
     <relativePath>../pom.xml</relativePath>
     <version>4.0-SNAPSHOT</version>
   </parent>

--- a/cal-recon/pom.xml
+++ b/cal-recon/pom.xml
@@ -10,7 +10,7 @@
 
   <parent>
     <groupId>org.lcsim</groupId>
-    <artifactId>lcsim-parent</artifactId>
+    <artifactId>lcsim</artifactId>
     <relativePath>../pom.xml</relativePath>
     <version>4.0-SNAPSHOT</version>
   </parent>

--- a/conditions/pom.xml
+++ b/conditions/pom.xml
@@ -8,7 +8,7 @@
 
   <parent>
     <groupId>org.lcsim</groupId>
-    <artifactId>lcsim-parent</artifactId>
+    <artifactId>lcsim</artifactId>
     <version>4.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>

--- a/detector-data/pom.xml
+++ b/detector-data/pom.xml
@@ -9,7 +9,7 @@
 
   <parent>
     <groupId>org.lcsim</groupId>
-    <artifactId>lcsim-parent</artifactId>
+    <artifactId>lcsim</artifactId>
     <relativePath>../pom.xml</relativePath>
     <version>4.0-SNAPSHOT</version>
   </parent>

--- a/detector-framework/pom.xml
+++ b/detector-framework/pom.xml
@@ -8,7 +8,7 @@
 
   <parent>
     <groupId>org.lcsim</groupId>
-    <artifactId>lcsim-parent</artifactId>
+    <artifactId>lcsim</artifactId>
     <version>4.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>

--- a/detector-framework/pom.xml
+++ b/detector-framework/pom.xml
@@ -105,6 +105,11 @@
       <artifactId>reflections</artifactId>
       <version>0.9.9</version>
     </dependency>
+    <dependency>
+      <groupId>net.jafama</groupId>
+      <artifactId>jafama</artifactId>
+      <version>2.1.0</version>
+    </dependency>
   </dependencies>
 
 </project>

--- a/detector-framework/src/main/java/org/lcsim/detector/DetectorElement.java
+++ b/detector-framework/src/main/java/org/lcsim/detector/DetectorElement.java
@@ -329,7 +329,7 @@ public class DetectorElement implements IDetectorElement
         }
 
         // Look recursively through the children.
-        if (hasChildren())
+        if ((!hasGeometryInfo() || srch != null) && hasChildren())
         {
             for (IDetectorElement child : getChildren())
             {
@@ -337,6 +337,7 @@ public class DetectorElement implements IDetectorElement
                 if (childSrch != null)
                 {
                     srch = childSrch;
+                    break;
                 }
             }
         }

--- a/detector-framework/src/main/java/org/lcsim/detector/solids/AbstractPolyhedron.java
+++ b/detector-framework/src/main/java/org/lcsim/detector/solids/AbstractPolyhedron.java
@@ -32,11 +32,12 @@ public abstract class AbstractPolyhedron extends AbstractSolid implements IPolyh
     {
         Point3D point = new Point3D(p);
         
-        boolean inside = true;
+        boolean inside = false;
         for (Polygon3D face : getFaces())
         {
             if (GeomOp3D.intersects(point,face)) return Inside.SURFACE;
-            inside = inside && (GeomOp3D.distanceBetween(point,face.getPlane()) < 0);
+            if (!(inside = GeomOp3D.distanceBetween(point,face.getPlane()) < 0))
+                break;
         }
         
         if (inside) return Inside.INSIDE;

--- a/detector-framework/src/main/java/org/lcsim/detector/solids/GeomOp3D.java
+++ b/detector-framework/src/main/java/org/lcsim/detector/solids/GeomOp3D.java
@@ -3,6 +3,7 @@ package org.lcsim.detector.solids;
 import hep.physics.matrix.BasicMatrix;
 import hep.physics.vec.Hep3Vector;
 import hep.physics.vec.VecOp;
+import net.jafama.FastMath;
 
 import java.util.List;
 
@@ -130,7 +131,7 @@ public class GeomOp3D
             }
             else
             {
-                angle_sum += Math.acos(VecOp.dot(v1_vec,v2_vec)/(v1_mag*v2_mag));
+                angle_sum += net.jafama.FastMath.acos(VecOp.dot(v1_vec,v2_vec)/(v1_mag*v2_mag));
             }
         }
         

--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -8,7 +8,7 @@
 
   <parent>
     <groupId>org.lcsim</groupId>
-    <artifactId>lcsim-parent</artifactId>
+    <artifactId>lcsim</artifactId>
     <version>4.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>

--- a/event-heprep/pom.xml
+++ b/event-heprep/pom.xml
@@ -8,7 +8,7 @@
 
   <parent>
     <groupId>org.lcsim</groupId>
-    <artifactId>lcsim-parent</artifactId>
+    <artifactId>lcsim</artifactId>
     <version>4.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>

--- a/event-model/pom.xml
+++ b/event-model/pom.xml
@@ -8,7 +8,7 @@
 
   <parent>
     <groupId>org.lcsim</groupId>
-    <artifactId>lcsim-parent</artifactId>
+    <artifactId>lcsim</artifactId>
     <version>4.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>

--- a/event-processing/pom.xml
+++ b/event-processing/pom.xml
@@ -8,7 +8,7 @@
 
   <parent>
     <groupId>org.lcsim</groupId>
-    <artifactId>lcsim-parent</artifactId>
+    <artifactId>lcsim</artifactId>
     <version>4.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -8,7 +8,7 @@
 
   <parent>
     <groupId>org.lcsim</groupId>
-    <artifactId>lcsim-parent</artifactId>
+    <artifactId>lcsim</artifactId>
     <relativePath>../pom.xml</relativePath>
     <version>3.0.4-SNAPSHOT</version>
   </parent>

--- a/job-manager/pom.xml
+++ b/job-manager/pom.xml
@@ -8,7 +8,7 @@
 
   <parent>
     <groupId>org.lcsim</groupId>
-    <artifactId>lcsim-parent</artifactId>
+    <artifactId>lcsim</artifactId>
     <version>4.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>

--- a/math/pom.xml
+++ b/math/pom.xml
@@ -8,7 +8,7 @@
 
   <parent>
     <groupId>org.lcsim</groupId>
-    <artifactId>lcsim-parent</artifactId>
+    <artifactId>lcsim</artifactId>
     <version>4.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>

--- a/mc/pom.xml
+++ b/mc/pom.xml
@@ -8,7 +8,7 @@
 
   <parent>
     <groupId>org.lcsim</groupId>
-    <artifactId>lcsim-parent</artifactId>
+    <artifactId>lcsim</artifactId>
     <version>4.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>

--- a/plugin/pom.xml
+++ b/plugin/pom.xml
@@ -8,7 +8,7 @@
 
   <parent>
     <groupId>org.lcsim</groupId>
-    <artifactId>lcsim-parent</artifactId>
+    <artifactId>lcsim</artifactId>
     <version>4.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>

--- a/recon-drivers/pom.xml
+++ b/recon-drivers/pom.xml
@@ -8,7 +8,7 @@
 
   <parent>
     <groupId>org.lcsim</groupId>
-    <artifactId>lcsim-parent</artifactId>
+    <artifactId>lcsim</artifactId>
     <version>4.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>

--- a/steering-files/pom.xml
+++ b/steering-files/pom.xml
@@ -9,7 +9,7 @@
 
   <parent>
     <groupId>org.lcsim</groupId>
-    <artifactId>lcsim-parent</artifactId>
+    <artifactId>lcsim</artifactId>
     <relativePath>../pom.xml</relativePath>
     <version>4.0-SNAPSHOT</version>
   </parent>

--- a/tracking/pom.xml
+++ b/tracking/pom.xml
@@ -8,7 +8,7 @@
 
   <parent>
     <groupId>org.lcsim</groupId>
-    <artifactId>lcsim-parent</artifactId>
+    <artifactId>lcsim</artifactId>
     <version>4.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>

--- a/trf/pom.xml
+++ b/trf/pom.xml
@@ -9,7 +9,7 @@
 
   <parent>
     <groupId>org.lcsim</groupId>
-    <artifactId>lcsim-parent</artifactId>
+    <artifactId>lcsim</artifactId>
     <relativePath>../pom.xml</relativePath>
     <version>4.0-SNAPSHOT</version>
   </parent>

--- a/users/pom.xml
+++ b/users/pom.xml
@@ -9,7 +9,7 @@
 
   <parent>
     <groupId>org.lcsim</groupId>
-    <artifactId>lcsim-parent</artifactId>
+    <artifactId>lcsim</artifactId>
     <relativePath>../pom.xml</relativePath>
     <version>4.0-SNAPSHOT</version>
   </parent>

--- a/util/pom.xml
+++ b/util/pom.xml
@@ -9,7 +9,7 @@
 
   <parent>
     <groupId>org.lcsim</groupId>
-    <artifactId>lcsim-parent</artifactId>
+    <artifactId>lcsim</artifactId>
     <version>4.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>

--- a/vertexing/pom.xml
+++ b/vertexing/pom.xml
@@ -8,7 +8,7 @@
 
   <parent>
     <groupId>org.lcsim</groupId>
-    <artifactId>lcsim-parent</artifactId>
+    <artifactId>lcsim</artifactId>
     <version>4.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>


### PR DESCRIPTION
Three separate improvements are included in this request:

* Replaced inverse cosine function in GeomOp3D.intersects(Point3D, Polygon3D) with the function provided in the Java Fast Math library (thanks to Sergei Chekanov for discovering this library).
* Prevent unnecessary recursion in DetectorElement.findDetectorElement(Hep3Vector).  Recursion does not occur if not in parent volume, and loop over children breaks when a match is found.
* Prevent unnecessary looping over faces in AbstractPolyhedron.inside(Hep3Vector).  Loop now breaks when point is found to be on wrong side of any face.  I am also skeptical that the line above should be the way it is, where it returns Inside.SURFACE.  This could in principle occur in the plane of a surface while not on the surface of the actual 3D object.

All of these combined tend to speed up digitization by better than an order of magnitude.

EDIT:  Also added fix for parent artifact name