### PR TITLE
added new dummy constructor to BaseTrackState

### DIFF
--- a/event-model/src/main/java/org/lcsim/event/base/BaseTrackState.java
+++ b/event-model/src/main/java/org/lcsim/event/base/BaseTrackState.java
@@ -32,6 +32,9 @@ public class BaseTrackState implements TrackState
     public BaseTrackState()
     {}
     
+    public BaseTrackState(int location)
+    {_location = location; }
+    
     //fully qualified constructor
     public BaseTrackState(double[] trackParameters, double[] covarianceMatrix, double[] position, int location)
     {


### PR DESCRIPTION
I'd like to add an extra constructor to BaseTrackState.java , which takes only one parameter:
public BaseTrackState(int location)
{ _location = location; }
This would allow me to create "dummy" TrackStates with location -1, to represent unhit sensors in List. Setting the location to -1 is OK everywhere except in BaseTrackState.SetLocation(), which is called by the BaseTrackState constructors and requires the location to be 0 to 5; the extra constructor bypasses this check.