### PR TITLE
change check in BaseTrackState.SetLocation() to allow -1

### DIFF
--- a/event-model/src/main/java/org/lcsim/event/base/BaseTrackState.java
+++ b/event-model/src/main/java/org/lcsim/event/base/BaseTrackState.java
@@ -127,7 +127,7 @@ public class BaseTrackState implements TrackState
     
     public void setLocation(int location)
     {
-        if (location < 0 || location > TrackState.LastLocation)
+        if (location < -1 || location > TrackState.LastLocation)
             throw new IllegalArgumentException("The location must be between 0 and " + TrackState.LastLocation);
         this._location = location;
     }


### PR DESCRIPTION
Unfortunately we do need to change the SetLocation() to allow -1, because it gets called when recreating TrackStates from lcio files being read back in by certain hps-java tools