### PR TITLE
Use ~/.cache/lcsim as default cache dir.

### DIFF
--- a/util/src/main/java/org/lcsim/util/cache/FileCache.java
+++ b/util/src/main/java/org/lcsim/util/cache/FileCache.java
@@ -15,7 +15,7 @@ import java.net.URLEncoder;
  * @author tonyj
  */
 public class FileCache {
-    private static final File home = new File(getCacheRoot(), ".cache");
+    private static final File home = new File(getCacheRoot(), ".cache/lcsim");
     private static final ByteFormat format = new ByteFormat();
     private File cache;
     private PrintStream print = System.out;


### PR DESCRIPTION
The previous directory `~/.cache` is used by many programs on Linux, so it is a mess to use it as the default cache area for lcsim and directly write files there.